### PR TITLE
Potential fix for code scanning alert no. 33: Uncontrolled data used in path expression

### DIFF
--- a/server/src/utils/cloudinary.js
+++ b/server/src/utils/cloudinary.js
@@ -1,7 +1,9 @@
 import { v2 as cloudinary } from "cloudinary";
 import fs from "fs";
+import path from "path";
 
-// Configuration
+// Only allow file operations within this safe upload folder (adjust as necessary)
+const SAFE_UPLOADS_ROOT = path.resolve(process.cwd(), "uploads"); // e.g., /app/uploads
 cloudinary.config({
     cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
     api_key: process.env.CLOUDINARY_API_KEY,
@@ -12,9 +14,16 @@ const uploadOnCloudinary = async (localFilePath) => {
     try {
         if (!localFilePath) return null; // Return null if no file path is provided
 
-        // Upload an fie to Cloudinary
+        // Ensure file path is under safe folder
+        const resolvedPath = path.resolve(localFilePath);
+        if (!resolvedPath.startsWith(SAFE_UPLOADS_ROOT + path.sep)) {
+            console.error(`Refusing to operate on file outside safe upload folder: ${resolvedPath}`);
+            return null;
+        }
+
+        // Upload an file to Cloudinary
         const uploadResult = await cloudinary.uploader
-            .upload(localFilePath, {
+            .upload(resolvedPath, {
                 resource_type: "auto", // The type of file. 'auto' will automatically detect the type of file
                 crop: "auto",
                 gravity: "auto",
@@ -26,10 +35,14 @@ const uploadOnCloudinary = async (localFilePath) => {
             });
 
         //console.log(`Files is uploaded successfully: ${uploadResult.url}`);
-        fs.unlinkSync(localFilePath); //Delete the locally saved file if it successfully uploaded
+        fs.unlinkSync(resolvedPath); //Delete the locally saved file if it successfully uploaded
         return uploadResult;
     } catch (error) {
-        fs.unlinkSync(localFilePath); // Delete the locally saved file if it fails to upload
+        // Only attempt to delete if actually inside the safe folder
+        const resolvedPath = path.resolve(localFilePath);
+        if (resolvedPath.startsWith(SAFE_UPLOADS_ROOT + path.sep)) {
+            fs.unlinkSync(resolvedPath);
+        }
         return null;
     }
 };
@@ -38,9 +51,15 @@ const tripUploadOnCloudinary = async (localFilePath) => {
     try {
         if (!localFilePath) return null; // Return null if no file path is provided
 
-        // Upload an fie to Cloudinary
+        const resolvedPath = path.resolve(localFilePath);
+        if (!resolvedPath.startsWith(SAFE_UPLOADS_ROOT + path.sep)) {
+            console.error(`Refusing to operate on file outside safe upload folder: ${resolvedPath}`);
+            return null;
+        }
+
+        // Upload an file to Cloudinary
         const uploadResult = await cloudinary.uploader
-            .upload(localFilePath, {
+            .upload(resolvedPath, {
                 resource_type: "auto", // The type of file. 'auto' will automatically detect the type of file
                 crop: "auto",
                 gravity: "auto",
@@ -52,10 +71,13 @@ const tripUploadOnCloudinary = async (localFilePath) => {
             });
 
         //console.log(`Files is uploaded successfully: ${uploadResult.url}`);
-        fs.unlinkSync(localFilePath); //Delete the locally saved file if it successfully uploaded
+        fs.unlinkSync(resolvedPath); //Delete the locally saved file if it successfully uploaded
         return uploadResult;
     } catch (error) {
-        fs.unlinkSync(localFilePath); // Delete the locally saved file if it fails to upload
+        const resolvedPath = path.resolve(localFilePath);
+        if (resolvedPath.startsWith(SAFE_UPLOADS_ROOT + path.sep)) {
+            fs.unlinkSync(resolvedPath);
+        }
         return null;
     }
 };


### PR DESCRIPTION
Potential fix for [https://github.com/faisalnightstar/PairUp-Connect-Explore/security/code-scanning/33](https://github.com/faisalnightstar/PairUp-Connect-Explore/security/code-scanning/33)

The optimal fix is to restrict deletion and access of files to a tightly controlled workspace (e.g., a specific temporary uploads directory). Before acting on `localFilePath`, check that it is within a safe uploads root folder. For this, resolve the absolute path and verify it starts with the intended directory (such as `/tmp/uploads/`). If it does not, refuse to operate (e.g., throw an error or return null).  
Specifically, do this in `tripUploadOnCloudinary` and, for consistency, also in `uploadOnCloudinary`. You will need to:
- Import `path` for proper path resolution.
- Define a constant like `SAFE_UPLOADS_ROOT` (e.g., `/tmp/uploads/`—adjust as appropriate for your setup).
- Before any use of `fs.unlinkSync(localFilePath)` or Cloudinary upload, resolve and check paths.
- If the path is not in the safe root, abort operation and return null, logging an error.

No complex changes or invasive refactoring are required beyond these measures in the relevant utility file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
